### PR TITLE
Remove the "Rivet" name from in front of API names.

### DIFF
--- a/_documentation/content-api/index.md
+++ b/_documentation/content-api/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Rivet Content API
+title: Content API
 summary: The Content API allows you to access the assets your customers contribute. You can use this API to build your own custom displays.
 ---
 The Rivet Platform allows brands and retailers to collect a variety of engaging user generated content – including rich media (photos and videos), geolocation, and commentary – directly from their customers. Rivet offers a collection of embeddable JavaScript displays that allow brands and retailers to easily display the user generated content on their own websites using only a few lines of code. For those customers in search of a more custom display experience, we offer the Rivet Content API. Customers can use the API to create their own galleries of user generated content and integrate the content anywhere on their website.

--- a/_documentation/submission-api/index.md
+++ b/_documentation/submission-api/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Rivet Submission API
+title: Submission API
 exclude: true
 ---
 This is the Submission API

--- a/_documentation/tracking-api/index.md
+++ b/_documentation/tracking-api/index.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: Rivet Tracking API
-summary: The Tracking API enables Rivet analytics and reporting data work for you when you build custom displays. 
+title: Tracking API
+summary: The Tracking API enables Rivet analytics and reporting data work for you when you build custom displays.
 ---
 We have a tracking API that we use for all the interactions with our Rivet displays, collectors, and conversions.
 


### PR DESCRIPTION
Signed-off-by: Mike Korte <korte@rivet.works>