### PR TITLE
Add a case statement to control what icons appear for which callouts.

### DIFF
--- a/_includes/callout.html
+++ b/_includes/callout.html
@@ -1,6 +1,17 @@
+
+
 <div class="callout-block callout-{{ include.type }}">
     <div class="icon-holder">
-        <i class="fa fa-exclamation-triangle"></i>
+      {% case include.type %}
+        {% when 'warning' %}
+          <i class="fa fa-bug"></i>
+        {% when 'success' %}
+          <i class="fa fa-thumbs-up"></i>
+        {% when 'danger' %}
+          <i class="fa fa-exclamation-triangle"></i>
+        {% else %}
+          <i class="fa fa-info-circle"></i>
+      {% endcase %}
     </div><!--//icon-holder-->
     <div class="content">
         <h4 class="callout-title">{{ include.title }}</h4>


### PR DESCRIPTION
Signed-off-by: Mike Korte <korte@rivet.works>